### PR TITLE
Removed erroneous throws, added URL Safe Encoding Helper

### DIFF
--- a/Source/Base64.swift
+++ b/Source/Base64.swift
@@ -131,6 +131,10 @@ public struct Base64 {
 
         return encoded
     }
+    
+    func urlSafeEncode(_ data: Data) throws -> String {
+        return Base64.encode(data, specialChars: "-_", paddingChar: nil)
+    }
 }
 
 extension Base64 {

--- a/Source/Base64.swift
+++ b/Source/Base64.swift
@@ -132,7 +132,7 @@ public struct Base64 {
         return encoded
     }
     
-    func urlSafeEncode(_ data: Data) throws -> String {
+    public func urlSafeEncode(_ data: Data) -> String {
         return Base64.encode(data, specialChars: "-_", paddingChar: nil)
     }
 }

--- a/Source/Base64.swift
+++ b/Source/Base64.swift
@@ -25,7 +25,7 @@
 @_exported import C7
 
 public struct Base64 {
-    public static func decode(_ string: String) throws -> Data {
+    public static func decode(_ string: String) -> Data {
         let ascii: [Byte] = [
             64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
             64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -51,7 +51,7 @@ public struct Base64 {
 
         for character in string.utf8 {
             if ascii[Int(character)] > 63 {
-                throw Base64Error.InvalidCharacter
+                break
             }
 
             unreadBytes += 1
@@ -141,8 +141,4 @@ extension Base64 {
     public static func encode(_ convertible: DataConvertible) -> String {
         return encode(convertible.data)
     }
-}
-
-public enum Base64Error: ErrorProtocol {
-    case InvalidCharacter
 }

--- a/Source/Base64.swift
+++ b/Source/Base64.swift
@@ -51,7 +51,7 @@ public struct Base64 {
 
         for character in string.utf8 {
             if ascii[Int(character)] > 63 {
-                break
+                throw Base64Error.InvalidCharacter
             }
 
             unreadBytes += 1
@@ -87,7 +87,7 @@ public struct Base64 {
         return decoded
     }
 
-	public static func encode(_ data: Data, specialChars: String = "+/", paddingChar: Character? = "=") throws -> String {
+	public static func encode(_ data: Data, specialChars: String = "+/", paddingChar: Character? = "=") -> String {
         let base64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" + specialChars
         var encoded: String = ""
 
@@ -134,7 +134,11 @@ public struct Base64 {
 }
 
 extension Base64 {
-    public static func encode(_ convertible: DataConvertible) throws -> String {
-        return try encode(convertible.data)
+    public static func encode(_ convertible: DataConvertible) -> String {
+        return encode(convertible.data)
     }
+}
+
+public enum Base64Error: ErrorProtocol {
+    case InvalidCharacter
 }


### PR DESCRIPTION
URL / Filesystem safe encoding is documented here in the Base64 RFC: https://tools.ietf.org/html/rfc4648#section-5
